### PR TITLE
Use fully-qualified macro name or use syntax quote

### DIFF
--- a/test/test_case/core_test.clj
+++ b/test/test_case/core_test.clj
@@ -7,7 +7,11 @@
   (assert false)
   (catch Exception ex (println "Got an exception")))
 
-(expect Exception (macroexpand-1 '(unstable)))
+;; because of quoting and the macro expansion of expect itself, this does not work:
+;; (expect Exception (macroexpand-1 '(unstable)))
+;; but both of these do (note the ` instead of ' in the second one):
+(expect Exception (macroexpand-1 '(test-case.core/unstable)))
+(expect Exception (macroexpand-1 `(unstable)))
 
 ;Alia:test-case matt$ lein autoexpect
 ;


### PR DESCRIPTION
    `(unstable)

This resolves the symbol fully, so that the macro is found, and the name is not just treated as the (unqualified) symbol `unstable`.